### PR TITLE
Make is_title_mismatched more pythonic

### DIFF
--- a/swaglyrics_backend/issue_maker.py
+++ b/swaglyrics_backend/issue_maker.py
@@ -16,7 +16,8 @@ from requests.auth import HTTPBasicAuth
 from swaglyrics import __version__
 from swaglyrics.cli import stripper, spc
 
-from swaglyrics_backend.utils import request_from_github, validate_request, get_jwt, get_installation_access_token
+from swaglyrics_backend.utils import request_from_github, validate_request, get_jwt, get_installation_access_token, \
+    log_args
 
 # start flask app
 app = Flask(__name__)
@@ -169,10 +170,10 @@ def genius_stripper(song: str, artist: str) -> Optional[str]:
             hits = data['response']['hits']
             for hit in hits:
                 full_title = hit['result']['full_title']
-                logging.info(f'    full title: {full_title}')
+                logging.info(f'\tfull title: {full_title}')
                 # remove punctuation before comparison
                 full_title = re.sub(alg, '', full_title)
-                logging.info(f'    stripped full title: {full_title}')
+                logging.info(f'\tstripped full title: {full_title}')
 
                 if not is_title_mismatched(words, full_title, max_err):
                     # return stripper as no mismatch
@@ -188,6 +189,7 @@ def genius_stripper(song: str, artist: str) -> Optional[str]:
             return None
 
 
+@log_args()
 def is_title_mismatched(words: List[str], full_title: str, max_err: int) -> bool:
     mismatch = [word for word in words if word.lower() not in full_title.lower()]
     logging.debug(f"broke on {mismatch}")

--- a/swaglyrics_backend/issue_maker.py
+++ b/swaglyrics_backend/issue_maker.py
@@ -172,7 +172,7 @@ def genius_stripper(song: str, artist: str) -> Optional[str]:
                 logging.info(f'    full title: {full_title}')
                 # remove punctuation before comparison
                 full_title = re.sub(alg, '', full_title)
-                logging.info(f'   stripped full title: {full_title}')
+                logging.info(f'    stripped full title: {full_title}')
 
                 if not is_title_mismatched(words, full_title, max_err):
                     # return stripper as no mismatch
@@ -189,14 +189,9 @@ def genius_stripper(song: str, artist: str) -> Optional[str]:
 
 
 def is_title_mismatched(words: List[str], full_title: str, max_err: int) -> bool:
-    err_cnt = 0
-    for word in words:
-        if word.lower() not in full_title.lower():
-            err_cnt += 1
-            logging.debug(f'broke on {word}')
-            if err_cnt > max_err:
-                return True
-    return False
+    mismatch = [word for word in words if word.lower() not in full_title.lower()]
+    logging.debug(f"broke on {mismatch}")
+    return len(mismatch) > max_err
 
 
 def create_issue(song: str, artist: str, version: str, stripper: str = 'not supported yet') -> JSONDict:


### PR DESCRIPTION
the tests for this need to be better btw, to account for cases where lower upper case makes a difference.

also one problem is that we compare words in a string, so like `'yo' in 'your'` will return true which we might not want.

@flabbet I was hoping you could review it once since you touched this function last 😃 

Signed-off-by: Aadi Bajpai <me@aadibajpai.me>