### PR TITLE
Improve Genius title matching

### DIFF
--- a/swaglyrics_backend/issue_maker.py
+++ b/swaglyrics_backend/issue_maker.py
@@ -189,7 +189,7 @@ def genius_stripper(song: str, artist: str) -> Optional[str]:
 
 @log_args(max_chars=-1)
 def is_title_mismatched(words: List[str], full_title: str, max_err: int) -> bool:
-    mismatch = [word for word in words if word.lower() not in full_title.lower()]
+    mismatch = [word for word in words if word.lower() not in full_title.lower().split()]
     logging.debug(f"broke on {mismatch}")
     return len(mismatch) > max_err
 

--- a/tests/sample_genius_data.json
+++ b/tests/sample_genius_data.json
@@ -54,7 +54,7 @@
           "id": 4317921,
           "lyrics_owner_id": 7918137,
           "lyrics_state": "complete",
-          "path": "/Caravan-palace-miracle-traduction-francaise-lyrics",
+          "path": "/Caravan-palace-miracle-traduction-francaise-aaaaafake",
           "pyongs_count": null,
           "song_art_image_thumbnail_url": "https://images.genius.com/ca9236bb9c4f5bd7065c3b9b8684aea5.300x300x1.jpg",
           "song_art_image_url": "https://images.genius.com/ca9236bb9c4f5bd7065c3b9b8684aea5.1000x1000x1.jpg",
@@ -192,13 +192,13 @@
         "result": {
           "annotation_count": 1,
           "api_path": "/songs/1259613",
-          "full_title": "Caravan by Utopia",
+          "full_title": "Not Caravan by Utopia",
           "header_image_thumbnail_url": "https://images.genius.com/f7e576e0d12167b15d3f51ba1fc33e2d.300x300x1.jpg",
           "header_image_url": "https://images.genius.com/f7e576e0d12167b15d3f51ba1fc33e2d.1000x1000x1.jpg",
           "id": 1259613,
           "lyrics_owner_id": 5593635,
           "lyrics_state": "complete",
-          "path": "/Utopia-caravan-lyrics",
+          "path": "/Utopia-caravan-annotated",
           "pyongs_count": null,
           "song_art_image_thumbnail_url": "https://images.genius.com/f7e576e0d12167b15d3f51ba1fc33e2d.300x300x1.jpg",
           "song_art_image_url": "https://images.genius.com/f7e576e0d12167b15d3f51ba1fc33e2d.1000x1000x1.jpg",
@@ -206,7 +206,7 @@
             "unreviewed_annotations": 0,
             "hot": false
           },
-          "title": "Caravan",
+          "title": "Not Caravan",
           "title_with_featured": "Caravan",
           "url": "https://genius.com/Utopia-caravan-lyrics",
           "primary_artist": {

--- a/tests/test_issue_maker.py
+++ b/tests/test_issue_maker.py
@@ -244,6 +244,8 @@ class TestIssueMaker(TestBase):
         fake_json['response']['hits'][0]['result']['path'] = "/Caravan-palace-miracle-annotated"  # no lyrics at end
         # adjust titles so none match
         fake_json['response']['hits'][1]['result']["full_title"] = "fake title"
+        fake_json['response']['hits'][1]['result']["name"] = "fake song"
+        fake_json['response']['hits'][1]['result']["primary_artist"]["name"] = "fake name"
         fake_json['response']['hits'][4]['result']["full_title"] = "fake title"
         fake_json['response']['hits'][5]['result']["full_title"] = "fake title"
 
@@ -263,15 +265,18 @@ class TestIssueMaker(TestBase):
 
     def test_that_title_mismatches(self):
         from swaglyrics_backend.issue_maker import is_title_mismatched
-        assert is_title_mismatched(["Bohemian", "Rhapsody", "by", "Queen"], "Miracle by Caravan Palace", 2)
+        assert is_title_mismatched("Bohemian Rhapsody by Queen", "Miracle", "Caravan Palace", "Miracle",
+                                   "Caravan Palace", 2)
 
     def test_that_title_not_mismatches(self):
         from swaglyrics_backend.issue_maker import is_title_mismatched
-        assert not is_title_mismatched(["Bohemian", "Rhapsody", "by", "Queen"], "bohemian rhapsody by queen", 2)
+        assert not is_title_mismatched("Bohemian Rhapsody by Queen", "bohemian rhapsody", "queen", "Bohemian Rhapsody",
+                                       "Queen", 2)
 
     def test_that_title_not_mismatches_with_one_error(self):
         from swaglyrics_backend.issue_maker import is_title_mismatched
-        assert not is_title_mismatched(["BoHemIaN", "RhaPsoDy", "2011", "bY", "queen"], "bohemian RHAPSODY By QUEEN", 2)
+        assert not is_title_mismatched("Bohemian Rhapsody by Queen", "bohemian RHAPSODY", "QUEEN", "Bohemian Rhapsody",
+                                       "Queen", 2)
 
     @patch('swaglyrics_backend.issue_maker.get_github_token', return_value='fake token')
     @patch('swaglyrics_backend.issue_maker.requests.post')


### PR DESCRIPTION
issues in mind:
- current comparison checks for list elements in a string, the disadvantage of this is that partial matches will return true, as in `'na' in 'banana'` or `'sass' in 'assassination'` will return true but with list comparison, `'na' in ['banana']` will return false.

- one sort of false positives is when a different song of the same artist is returned. eg. 
![image](https://user-images.githubusercontent.com/27063113/88180186-9fde1780-cc4a-11ea-9f4b-be9eed7709bf.png)
this can be fixed by checking the song name specifically but then

- this creates a problem with how the discord bot works, people are supposed to specify song artist like "rap god" "eminem" but no one bothers to read help so they just do rap god eminem, which gets treated as song=rap, artist=god, the bot still manages to return lyrics because of lax matching. 

- for remixes, song name will remain same but artist might be referring to the remix artist which would again trip up the matcher if artist is specifically compared.



Signed-off-by: Aadi Bajpai <me@aadibajpai.me>